### PR TITLE
Add Support for Text Injection into WebViews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 obj/
 bin/
 .vs/
+*.DS_Store

--- a/Sources/RepeatoCapture/include/RepeatoCapture.h
+++ b/Sources/RepeatoCapture/include/RepeatoCapture.h
@@ -813,7 +813,7 @@ static int frameno; // count of frames captured and transmmitted
             CGPoint location = {rpevent.touches[0].x, rpevent.touches[0].y},
                 location2 = {rpevent.touches[1].x, rpevent.touches[1].y};
             static UITextAutocorrectionType saveAuto;
-            static BOOL isTextfield, isKeyboard, isButton, isLandscape;
+            static BOOL isTextfield, isKeyboard, isButton;
             static UITextField *textField;
             static UITouch *currentTouch2;
             static UIView *currentTarget;
@@ -904,12 +904,6 @@ static int frameno; // count of frames captured and transmmitted
                 case RMTouchBegan:
                     currentTarget = nil;
                     
-                    Log(self, @"location ---> %@", NSStringFromCGPoint(location));
-                    UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
-                    isLandscape = UIInterfaceOrientationIsLandscape(orientation);
-                    
-                    Log(self, @"isLandscape ---> %@", isLandscape ? @"true" : @"false");
-                    
                     for (UIWindow *window in [UIApplication sharedApplication].windows) {
                         UIView *found = [window hitTest:location withEvent:fakeEvent];
                         if (found)
@@ -921,8 +915,6 @@ static int frameno; // count of frames captured and transmmitted
                             Log(self, @"Found webview: %@", foundWebView);
                             webView = (WKWebView *)foundWebView;
                         }
-
-                        Log(self, @"Current Target ---> %@", [currentTarget description]);
                     }
 
                     isTextfield = [currentTarget respondsToSelector:@selector(setAutocorrectionType:)];
@@ -1173,7 +1165,6 @@ static int frameno; // count of frames captured and transmmitted
 
     for (UITouch *touch in touches) {
         CGPoint loc = [touch locationInView:touch.window];
-        loc = [touch.window.layer convertPoint:loc toLayer:touch.window.layer.superlayer];
         header.phase = (RMTouchPhase)touch.phase;
         header.x = loc.x;
         header.y = loc.y;

--- a/Sources/RepeatoCapture/include/RepeatoCapture.h
+++ b/Sources/RepeatoCapture/include/RepeatoCapture.h
@@ -5,6 +5,7 @@
 #import <netdb.h>
 #import <netdb.h>
 #import <zlib.h>
+#import <WebKit/WebKit.h>
 
 #import "RepeatoHeaders.h"
 #import "Logger.h"
@@ -437,7 +438,7 @@ static char *connectionKey;
         FILE *writeFp = (FILE *)fp.pointerValue;
         int headerSize = 1 + sizeof device.remote;
         if (fwrite(&device, 1, headerSize, writeFp) != headerSize)
-            Log(self, @"Could not write device info: %s", strerror(errno));        
+            Log(self, @"Could not write device info: %s", strerror(errno));
         else if (device.version == REPEATO_VERSION &&
                  fwrite(&keylen, 1, sizeof keylen, writeFp) != sizeof keylen)
             Log(self, @"Could not write keylen: %s", strerror(errno));
@@ -751,6 +752,38 @@ static int frameno; // count of frames captured and transmmitted
         }
 }
 
+/// Finds the first descendant view of a given class name in a view hierarchy.
+/// @param view View to search through
+/// @param className Name of the class to search for
++ (UIView *)findDescendantViewInView:(UIView *)view withClassName:(NSString *)className {
+    if ([NSStringFromClass([view class]) isEqualToString:className]) {
+        return view;
+    }
+    for (UIView *subview in view.subviews) {
+        UIView *result = [self findDescendantViewInView:subview withClassName:className];
+        if (result) {
+            return result;
+        }
+    }
+    return nil;
+}
+
+/// Injects text into webview's HTML document. Must 'click'/focus on input before executing this function.
+/// @param text Text to be injected
+/// @param webView Web view to inject text into
++ (void)injectText:(NSString *)text intoWebView:(WKWebView *)webView {
+    NSString *js = [NSString stringWithFormat:
+            @"document.execCommand('insertText', false, '%@')", text];
+
+    [webView evaluateJavaScript:js completionHandler:^(id result, NSError *error) {
+        if (error) {
+            NSLog(@"Error injecting text: %@", error.localizedDescription);
+        } else {
+            NSLog(@"Text injected successfully");
+        }
+    }];
+}
+
 /// Run in backgrount to process event structs coming from user interface in order to forge them
 /// @param writeFp Connection to RemoteUI server
 + (void)processEvents:(NSValue *)writeFp {
@@ -780,11 +813,12 @@ static int frameno; // count of frames captured and transmmitted
             CGPoint location = {rpevent.touches[0].x, rpevent.touches[0].y},
                 location2 = {rpevent.touches[1].x, rpevent.touches[1].y};
             static UITextAutocorrectionType saveAuto;
-            static BOOL isTextfield, isKeyboard, isButton;
+            static BOOL isTextfield, isKeyboard, isButton, isLandscape;
             static UITextField *textField;
             static UITouch *currentTouch2;
             static UIView *currentTarget;
             static unsigned touchIdentifier = 120;
+            static WKWebView *webView;
             touchIdentifier++;
 
             static UITouchesEvent *event;
@@ -818,8 +852,15 @@ static int frameno; // count of frames captured and transmmitted
                     // send a new frame with the requested resolution right away
                     [self queueCapture];
                 } else {
-                    Log(self, @"Insert text");
-                    [textField insertText:sentText];
+                    if (textField != nil) {
+                        Log(self, @"Insert text");
+                        [textField insertText:sentText];
+                    } else if (webView != nil) {
+                        Log(self, @"Insert text into webview");
+                        [self injectText:sentText intoWebView:webView];
+                    } else {
+                        Log(self, @"No textfield or webview found");
+                    }
                 }
 
                 return;
@@ -862,10 +903,26 @@ static int frameno; // count of frames captured and transmmitted
 
                 case RMTouchBegan:
                     currentTarget = nil;
+                    
+                    Log(self, @"location ---> %@", NSStringFromCGPoint(location));
+                    UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+                    isLandscape = UIInterfaceOrientationIsLandscape(orientation);
+                    
+                    Log(self, @"isLandscape ---> %@", isLandscape ? @"true" : @"false");
+                    
                     for (UIWindow *window in [UIApplication sharedApplication].windows) {
                         UIView *found = [window hitTest:location withEvent:fakeEvent];
                         if (found)
                             currentTarget = found;
+                        
+                        /// Find WebView in the window
+                        UIView *foundWebView = [self findDescendantViewInView:window withClassName:@"RNCWKWebView"];
+                        if (foundWebView) {
+                            Log(self, @"Found webview: %@", foundWebView);
+                            webView = (WKWebView *)foundWebView;
+                        }
+
+                        Log(self, @"Current Target ---> %@", [currentTarget description]);
                     }
 
                     isTextfield = [currentTarget respondsToSelector:@selector(setAutocorrectionType:)];
@@ -1116,6 +1173,7 @@ static int frameno; // count of frames captured and transmmitted
 
     for (UITouch *touch in touches) {
         CGPoint loc = [touch locationInView:touch.window];
+        loc = [touch.window.layer convertPoint:loc toLayer:touch.window.layer.superlayer];
         header.phase = (RMTouchPhase)touch.phase;
         header.x = loc.x;
         header.y = loc.y;


### PR DESCRIPTION
## Motivation
This PR introduces functionality to inject text into `WKWebView` instances, enhancing the handling of user interface interactions for Repeato's Type Step on WebViews with text input.

## Key Changes
- Adds a new method `injectText:intoWebView:` to inject text into a `WKWebView`'s HTML document using JavaScript.
- Adds a utility method `findDescendantViewInView:withClassName:` to recursively search for a specific view type within a view hierarchy.
- Updates the processEvents: method to handle text insertion for both `UITextField` and `WKWebView` objects.
