### PR TITLE
iOS connector server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,21 @@
 # iOS Connector for Repeato Studio and Repeato CLI
 
 This open source library allows remote controlling iOS devices / simulators from an automation host.
+
 The connector library needs to be embedded into your app and takes care of transmitting and receiving data from [Repeato Studio](https://www.repeato.app) or [Repeato CLI](https://www.npmjs.com/package/@repeato/cli-testrunner).
+
+> This is the new connector that works a bit differently than the old one (v1.2.x, see documentation [here](https://github.com/repeato-qa/ios-connector/tree/1.2.8)). 
 
 # How does the connector work?
 
-When the app is launched, the connector tries to connect to the host (Repeato Studio or Repeato CLI) via a websocket connection. If the connection is established, the connector starts listening for incoming commands and executes them. The connector also sends back a video feed to the host.
+When the app is launched, the connector will open a server port that an automation host can connect to. As soon as a connection is established, the connector waits for incoming commands and executes them. The connector also sends back a video feed to the host (single jpeg frames).
 
-When the app is lauched on an iOS Simulators, the connector simply connects to localhost:1313. 
-When the app is launched on a physical device however, the connector does not know where to connect to (localhost doesn't work in this case). It's going to try to connect to the host the app was originally built on, but that doesn't always work.
+The port that the connector listens on can be configured via the `-port`launch argument. By default, the connector listens on port 1313.
 
-Therefore Repeato passes it's own host IP to the app via launch arguments. The connector then tries to connect to the host IP. 
-In case of a connection error, the connector shows a dialog to the user to help them debugging the issue.
+As long as there is no connection, the connector shows a dialog to the user to help them to debug potential issues.
 
-So when working with phyisical iOS devices, make sure you start the app via Repeato (either via a "Start app" step, or via the "Start last used app" button).
-Manual app launches most probably will not work.
+Make sure that you always launch the app via Repeato, which will take care of passing the right `-port` argument before establishing a connection.
+
 
 # Installation
 
@@ -60,7 +61,7 @@ In the next step just click "Add Package" once more.
 
 ### 3. Build an launch app
 
-That's it. Just build and run your project via Xcode on the simulator. Repeato connector will find your Repeato instance, and connect to it.
+That's it. Just build and run your project via Xcode on the simulator. If you (re) start the app via Repeato, the connector will be started automatically and Repeato can connect to it.
 
 ## Installation via CocoaPods
 
@@ -115,7 +116,7 @@ Check: When you launch the app, is this dialog shown?
 
 <img src="/docs/assets/ios-connector-dialog.png" width="50%" />
 
-**If YES**: Take a look at the line "Trying to connect to ...". The connector is trying to connect to that address. If that address is wrong, the app will not be able to connect to Repeato. If you are running the app on a simulator, the address can default to "localhost", that is fine. If you are running the app on a physical device however, the address of your machine, running Repeato, might not be known by the app. In that case, you need to start the app via Repeato (either via a "Start app" step, or via the "Start last used app" button). Manual app launches most probably will not work.
+**If YES**: The connector seems to be installed correctly, but for some reason Repeato might not be able to connect to it. Make sure that your device and Repeato run on the same network.
 
 **If NO**: You might need to check if the plugin is integrated properly. If you are not a developer, you might need to talk to one. The plugin is open source, so they might easily find the reason why the dialog is not shown.
 
@@ -123,19 +124,14 @@ Check: When you launch the app, is this dialog shown?
 (mostly internal documentation for our dev team)
 
 ## Connection debug dialog shown on device - how does it work?
-The connector shows a dialog on launch of the app to simplify debugging for the user in case of a connection issue. As soon as the connector connects to Repeato, the dialog is automatically closed.
+The connector shows a dialog on launch of the app to simplify debugging for the user in case of a connection issue. As soon as a connection is established, the dialog is automatically closed.
 
 Here are the details of how this dialog operates:
 
-1. If no connection possible on real device: show dialog with countdown and close app
-2. If no connection possible on simulator: show dialog with log, but no countdown and no app close
-3. If connection established: hide dialog and stop logging to text view
-4. If connection breaks on real device: show dialog with countdown and close app (in the future, we should try to reconnect automatically)
-5. If connection breaks on simulator: show dialog, but no countdown and no app close (in the future, we should try to reconnect automatically)
-6. If "Cancel" button is pressed, countdown and cancel button should be hidden and and app close should be canceled. Dialog should stay open
+1. If no connection possible: show dialog
+2. If connection established: hide dialog and stop logging to text view
+3. If connection breaks: show dialog
 
-**To sum it up**: It doesn't matter if host IP is known or not and if launch args are given or not: We show the dialog when there is no connection to the host (either because it is not yet established or it was not possible or the connection broke)
-Additionally we show a countdown and close the app if no connection is there BUT only on physical devices.
 
 ## Xamarin - How to create/update the bindings library.
 

--- a/Sources/RepeatoCapture/include/InfoMessages.h
+++ b/Sources/RepeatoCapture/include/InfoMessages.h
@@ -363,6 +363,7 @@ bool noLaunchArgPassed = false;
 
 #pragma mark Logger delegate
 - (void)logEvent:(NSString *)message {
+    //adding a 1 second delay so that textview is not nil as the connector send messages too quick before the UI is fully up and running.
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         if(self.tv == nil) {
             /// fall back to track logs before tv initializaiton

--- a/Sources/RepeatoCapture/include/InfoMessages.h
+++ b/Sources/RepeatoCapture/include/InfoMessages.h
@@ -363,23 +363,18 @@ bool noLaunchArgPassed = false;
 
 #pragma mark Logger delegate
 - (void)logEvent:(NSString *)message {
-    //adding a 1 second delay so that textview is not nil as the connector send messages too quick before the UI is fully up and running.
-    
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.001 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
         if(self.tv == nil) {
             /// fall back to track logs before tv initializaiton
             logsHistory = [logsHistory stringByAppendingString:[NSString stringWithFormat:@"%@\n", message]];
             return;
         }
-        
-        dispatch_async(dispatch_get_main_queue(), ^{
-            if(![logsHistory isEqualToString:@""]) {
-                self.tv.text = logsHistory;
-                logsHistory = @"";
-            }
-            [self.tv insertText:[NSString stringWithFormat:@"%@\n", message]];
-            [self textViewScrollToBottom];
-        });
+        if(![logsHistory isEqualToString:@""]) {
+            self.tv.text = logsHistory;
+            logsHistory = @"";
+        }
+        [self.tv insertText:[NSString stringWithFormat:@"%@\n", message]];
+        [self textViewScrollToBottom];
     });
 }
 

--- a/Sources/RepeatoCapture/include/InfoMessages.h
+++ b/Sources/RepeatoCapture/include/InfoMessages.h
@@ -9,7 +9,7 @@
 #import <UIKit/UIKit.h>
 #import "Logger.h"
 
-#define REPEATO_INFO_ABORT_DELAY 5
+#define REPEATO_INFO_ABORT_DELAY 15
 #define REPEATO_INFO_VIEW_TAG 1022
 #define REPEATO_INFO_ALERT_PADDING 20
 #define REPEATO_INFO_ALERT_INTERNAL_PADDING 8
@@ -60,15 +60,10 @@ bool noLaunchArgPassed = false;
     }
     Logger.shared.delegate = self;
     seconds = 0;
-    logsHistory = @"";
+    //logsHistory = @"";
     dispatch_async(dispatch_get_main_queue(), ^{
         [self setupAlertUI];
     });
-}
-
--(void) initAlertWithCountAndCancelOption {
-    [self initAlert];
-    [self noLaunchArgumentsPassed];
 }
 
 -(void) showAlert {
@@ -139,7 +134,7 @@ bool noLaunchArgPassed = false;
     #if TARGET_IPHONE_SIMULATOR
         [self initAlert];
     #else
-        [self initAlertWithCountAndCancelOption];
+        [self initAlert];
     #endif
 }
 

--- a/Sources/RepeatoCapture/include/InfoMessages.h
+++ b/Sources/RepeatoCapture/include/InfoMessages.h
@@ -363,18 +363,21 @@ bool noLaunchArgPassed = false;
 
 #pragma mark Logger delegate
 - (void)logEvent:(NSString *)message {
-    if(self.tv == nil) {
-        /// fall back to track logs before tv initializaiton
-        logsHistory = [logsHistory stringByAppendingString:[NSString stringWithFormat:@"%@\n", message]];
-        return;
-    }
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if(![logsHistory isEqualToString:@""]) {
-            self.tv.text = logsHistory;
-            logsHistory = @"";
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        if(self.tv == nil) {
+            /// fall back to track logs before tv initializaiton
+            logsHistory = [logsHistory stringByAppendingString:[NSString stringWithFormat:@"%@\n", message]];
+            return;
         }
-        [self.tv insertText:[NSString stringWithFormat:@"%@\n", message]];
-        [self textViewScrollToBottom];
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if(![logsHistory isEqualToString:@""]) {
+                self.tv.text = logsHistory;
+                logsHistory = @"";
+            }
+            [self.tv insertText:[NSString stringWithFormat:@"%@\n", message]];
+            [self textViewScrollToBottom];
+        });
     });
 }
 

--- a/Sources/RepeatoCapture/include/InfoMessages.h
+++ b/Sources/RepeatoCapture/include/InfoMessages.h
@@ -364,7 +364,8 @@ bool noLaunchArgPassed = false;
 #pragma mark Logger delegate
 - (void)logEvent:(NSString *)message {
     //adding a 1 second delay so that textview is not nil as the connector send messages too quick before the UI is fully up and running.
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.001 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         if(self.tv == nil) {
             /// fall back to track logs before tv initializaiton
             logsHistory = [logsHistory stringByAppendingString:[NSString stringWithFormat:@"%@\n", message]];

--- a/Sources/RepeatoCapture/include/RepeatoCapture.h
+++ b/Sources/RepeatoCapture/include/RepeatoCapture.h
@@ -506,6 +506,7 @@ static int clientSocket;
             Log(self, @"Accepted connection from %s:%d", clientIP, ntohs(clientAddr.sin_port));
             // Immediately send the device header to the connected client.
             [self initHeaderData];
+            [[InfoMessages shared] onConnect];
             
             long headerSize = sizeof(device);
             long wroteBytes = write(clientSocket, &device, headerSize);

--- a/Sources/RepeatoCapture/include/RepeatoCapture.h
+++ b/Sources/RepeatoCapture/include/RepeatoCapture.h
@@ -160,8 +160,8 @@ struct _rmevent {
 
 @interface REPEATO_APPNAME(Client)
 // Changed startCapture method to no longer require an address list
-+ (void)startCaptureWithScaleUpFactor:(float)s port:(int)port;
-+ (BOOL)startListeningOnPort:(int)port;
++ (void)startCaptureWithScaleUpFactor:(float)s port:(long)port;
++ (BOOL)startListeningOnPort:(long)port;
 + (void)shutdown;
 @end
 
@@ -430,7 +430,7 @@ static int clientSocket;
 // This method replaces the outbound connection logic.
 // It creates a listening socket, prints its IP address and port, and then accepts incoming connections.
 
-+ (BOOL)startListeningOnPort:(int)port {
++ (BOOL)startListeningOnPort:(long)port {
     Log(self, @"Start listening...");
     int serverSocket = socket(AF_INET, SOCK_STREAM, 0);
     if (serverSocket < 0) {
@@ -539,7 +539,7 @@ static int clientSocket;
 
 // Changed startCapture to no longer require a host address.
 // It now only sets parameters and calls initHeaderData followed by startListening.
-+ (void)startCaptureWithScaleUpFactor:(float)s port:(int)port {
++ (void)startCaptureWithScaleUpFactor:(float)s port:(long)port {
     scaleUpFactor = (s == 0 ? 1 : s);
     [UIApplication.sharedApplication setIdleTimerDisabled:YES];
     Log(self, @"Starting server with scaleUpFactor %.2f", scaleUpFactor);

--- a/Sources/RepeatoCapture/include/RepeatoCapture.h
+++ b/Sources/RepeatoCapture/include/RepeatoCapture.h
@@ -12,9 +12,6 @@
 #import "Logger.h"
 #import "InfoMessages.h"
 
-#ifndef REPEATO_PORT
-#define REPEATO_PORT 1313
-#endif
 
 #ifndef REPEATO_APPNAME
 #define REPEATO_APPNAME RepeatoCapture
@@ -160,8 +157,8 @@ struct _rmevent {
 
 @interface REPEATO_APPNAME(Client)
 // Changed startCapture method to no longer require an address list
-+ (void)startCaptureWithScaleUpFactor:(float)s port:(long)port;
-+ (BOOL)startListeningOnPort:(long)port;
++ (void)startCaptureWithScaleUpFactor:(float)s port:(int)port;
++ (BOOL)startListeningOnPort:(int)port;
 + (void)shutdown;
 @end
 
@@ -430,7 +427,7 @@ static int clientSocket;
 // This method replaces the outbound connection logic.
 // It creates a listening socket, prints its IP address and port, and then accepts incoming connections.
 
-+ (BOOL)startListeningOnPort:(long)port {
++ (BOOL)startListeningOnPort:(int)port {
     Log(self, @"Start listening...");
     int serverSocket = socket(AF_INET, SOCK_STREAM, 0);
     if (serverSocket < 0) {
@@ -446,7 +443,7 @@ static int clientSocket;
     struct sockaddr_in serverAddr;
     memset(&serverAddr, 0, sizeof(serverAddr));
     serverAddr.sin_family = AF_INET;
-    serverAddr.sin_port = htons(port > 0 ? port : REPEATO_PORT);
+    serverAddr.sin_port = htons(port > 0 ? port : REPEATO_DEFAULT_PORT);
     serverAddr.sin_addr.s_addr = INADDR_ANY;
     if (bind(serverSocket, (struct sockaddr *)&serverAddr, sizeof(serverAddr)) < 0) {
         Log(self, @"Error binding socket: %s", strerror(errno));
@@ -539,7 +536,7 @@ static int clientSocket;
 
 // Changed startCapture to no longer require a host address.
 // It now only sets parameters and calls initHeaderData followed by startListening.
-+ (void)startCaptureWithScaleUpFactor:(float)s port:(long)port {
++ (void)startCaptureWithScaleUpFactor:(float)s port:(int)port {
     scaleUpFactor = (s == 0 ? 1 : s);
     [UIApplication.sharedApplication setIdleTimerDisabled:YES];
     Log(self, @"Starting server with scaleUpFactor %.2f", scaleUpFactor);

--- a/Sources/RepeatoCapture/include/RepeatoImpl.m
+++ b/Sources/RepeatoCapture/include/RepeatoImpl.m
@@ -25,6 +25,7 @@
     NSArray *arguments = [[NSProcessInfo processInfo] arguments];
     DebugLog(self, @"Launch arguments", [arguments componentsJoinedByString:@","]);
     NSString *hostAddress = [[NSUserDefaults standardUserDefaults] stringForKey:@"host-address"];
+    NSString *cid = [[NSUserDefaults standardUserDefaults] stringForKey:@"cid"];
     float scaleUpFactor = [[NSUserDefaults standardUserDefaults] floatForKey:@"scale-up-factor"];
     
 #if TARGET_IPHONE_SIMULATOR
@@ -34,15 +35,16 @@
     }
 #endif
     if (hostAddress == NULL) {
-        DebugLog(self,@"Host-address launch argument not found. Launch arguments:", arguments);
+        DebugLog(self,@"-host-address launch argument not found. Launch arguments:", arguments);
         #ifdef DEVELOPER_HOST
-        Log(self,@"Host-address launch argument not found -> using fallback %s!", DEVELOPER_HOST);
-        [self startCapture:@DEVELOPER_HOST scaleUpFactor:scaleUpFactor];
+        Log(self,@"-host-address launch argument not found -> using fallback %s!", DEVELOPER_HOST);
+        [self startCapture:@DEVELOPER_HOST scaleUpFactor:scaleUpFactor cid:cid];
         #endif
         [[InfoMessages shared] noLaunchArgumentsPassed];
     } else {
-        Log(self,@"Host-address: %@", hostAddress);
-        [self startCapture:hostAddress scaleUpFactor:scaleUpFactor];
+        Log(self,@"-host-address: %@", hostAddress);
+        [[InfoMessages shared] showAlert];
+        [self startCapture:hostAddress scaleUpFactor:scaleUpFactor cid:cid];
         Log(self,@"Trying to connect to %@", hostAddress);
     }
     

--- a/Sources/RepeatoCapture/include/RepeatoImpl.m
+++ b/Sources/RepeatoCapture/include/RepeatoImpl.m
@@ -1,6 +1,5 @@
-
 #define REPEATO_HYBRID
-#define REPEATO_PORT 1313
+#define REPEATO_DEFAULT_PORT 1313
 #define REPEATO_OVERSAMPLE 2
 #define REPEATO_BENCHMARK
 #define REPEATO_DEFER 0.2
@@ -22,9 +21,13 @@
     NSArray *arguments = [[NSProcessInfo processInfo] arguments];
     DebugLog(self, @"Launch arguments", [arguments componentsJoinedByString:@","]);
     float scaleUpFactor = [[NSUserDefaults standardUserDefaults] floatForKey:@"scale-up-factor"];
-    long port = [[NSUserDefaults standardUserDefaults] integerForKey:@"port"];
+    // modified port parsing to include explicit cast
+    int port = (int)[[NSUserDefaults standardUserDefaults] integerForKey:@"port"];
     NSString *hostAddress = [[NSUserDefaults standardUserDefaults] stringForKey:@"host-address"];
     
+    if(port == 0){
+        port = REPEATO_DEFAULT_PORT;
+    }
     if([hostAddress length] != 0) {
         // if Repeato passes a host-address launch argument, it is a sign that it is an old Repeato version (<1.8.0)
         DebugLog(self, @"Error: \"%s\" This iOS connector version is too new for your Repeato version. Please upgrade Repeato to 1.8.x or downgrade the iOS connector version to 1.2.x", hostAddress);

--- a/Sources/RepeatoCapture/include/RepeatoImpl.m
+++ b/Sources/RepeatoCapture/include/RepeatoImpl.m
@@ -19,7 +19,7 @@
 + (void)load {
     [[InfoMessages shared] showAlert];
     NSArray *arguments = [[NSProcessInfo processInfo] arguments];
-    DebugLog(self, @"Launch arguments", [arguments componentsJoinedByString:@","]);
+    Log(self, @"Launch arguments: ", [arguments componentsJoinedByString:@","]);
     float scaleUpFactor = [[NSUserDefaults standardUserDefaults] floatForKey:@"scale-up-factor"];
     // modified port parsing to include explicit cast
     int port = (int)[[NSUserDefaults standardUserDefaults] integerForKey:@"port"];
@@ -30,7 +30,7 @@
     }
     if([hostAddress length] != 0) {
         // if Repeato passes a host-address launch argument, it is a sign that it is an old Repeato version (<1.8.0)
-        DebugLog(self, @"Error: \"%s\" This iOS connector version is too new for your Repeato version. Please upgrade Repeato to 1.8.x or downgrade the iOS connector version to 1.2.x", hostAddress);
+        Log(self, @"Error: This iOS connector version is too new for your Repeato version. Please upgrade Repeato to 1.8.x or downgrade the iOS connector version to 1.2.x");
     } else {
         [self startCaptureWithScaleUpFactor:scaleUpFactor port:port];
     }

--- a/Sources/RepeatoCapture/include/RepeatoImpl.m
+++ b/Sources/RepeatoCapture/include/RepeatoImpl.m
@@ -1,9 +1,6 @@
 
 #define REPEATO_HYBRID
-//#define REMOTE_MINICAP
 #define REPEATO_PORT 1313
-//#define REMOTE_PNGFORMAT
-//#define REPEATO_APPNAME GenericCapture
 #define REPEATO_OVERSAMPLE 2
 #define REPEATO_BENCHMARK
 #define REPEATO_DEFER 0.2
@@ -25,7 +22,7 @@
     NSArray *arguments = [[NSProcessInfo processInfo] arguments];
     DebugLog(self, @"Launch arguments", [arguments componentsJoinedByString:@","]);
     float scaleUpFactor = [[NSUserDefaults standardUserDefaults] floatForKey:@"scale-up-factor"];
-    int port = [[NSUserDefaults standardUserDefaults] integerForKey:@"port"];
+    long port = [[NSUserDefaults standardUserDefaults] integerForKey:@"port"];
     NSString *hostAddress = [[NSUserDefaults standardUserDefaults] stringForKey:@"host-address"];
     
     if([hostAddress length] != 0) {

--- a/Sources/RepeatoCapture/include/RepeatoImpl.m
+++ b/Sources/RepeatoCapture/include/RepeatoImpl.m
@@ -24,29 +24,14 @@
     [[InfoMessages shared] showAlert];
     NSArray *arguments = [[NSProcessInfo processInfo] arguments];
     DebugLog(self, @"Launch arguments", [arguments componentsJoinedByString:@","]);
-    NSString *hostAddress = [[NSUserDefaults standardUserDefaults] stringForKey:@"host-address"];
+    //NSString *hostAddress = [[NSUserDefaults standardUserDefaults] stringForKey:@"host-address"];
     NSString *cid = [[NSUserDefaults standardUserDefaults] stringForKey:@"cid"];
     float scaleUpFactor = [[NSUserDefaults standardUserDefaults] floatForKey:@"scale-up-factor"];
     
-#if TARGET_IPHONE_SIMULATOR
-    // on simulators we fall back to localhost, since the DEVELOPER_HOST (Host.current().name) turned out to be slightly unreliable
-    if (hostAddress == NULL) {
-        hostAddress = @"localhost";
-    }
-#endif
-    if (hostAddress == NULL) {
-        DebugLog(self,@"-host-address launch argument not found. Launch arguments:", arguments);
-        #ifdef DEVELOPER_HOST
-        Log(self,@"-host-address launch argument not found -> using fallback %s!", DEVELOPER_HOST);
-        [self startCapture:@DEVELOPER_HOST scaleUpFactor:scaleUpFactor cid:cid];
-        #endif
-        [[InfoMessages shared] noLaunchArgumentsPassed];
-    } else {
-        Log(self,@"-host-address: %@", hostAddress);
-        [[InfoMessages shared] showAlert];
-        [self startCapture:hostAddress scaleUpFactor:scaleUpFactor cid:cid];
-        Log(self,@"Trying to connect to %@", hostAddress);
-    }
-    
+    //#if TARGET_IPHONE_SIMULATOR
+        // on simulators we fall back to localhost, since the DEVELOPER_HOST (Host.current().name) turned out to be slightly unreliable
+    //#endif
+    [self startCaptureWithScaleUpFactor:scaleUpFactor cid:cid];
+  
 }
 @end

--- a/Sources/RepeatoCapture/include/RepeatoImpl.m
+++ b/Sources/RepeatoCapture/include/RepeatoImpl.m
@@ -24,14 +24,15 @@
     [[InfoMessages shared] showAlert];
     NSArray *arguments = [[NSProcessInfo processInfo] arguments];
     DebugLog(self, @"Launch arguments", [arguments componentsJoinedByString:@","]);
-    //NSString *hostAddress = [[NSUserDefaults standardUserDefaults] stringForKey:@"host-address"];
-    NSString *cid = [[NSUserDefaults standardUserDefaults] stringForKey:@"cid"];
     float scaleUpFactor = [[NSUserDefaults standardUserDefaults] floatForKey:@"scale-up-factor"];
+    int port = [[NSUserDefaults standardUserDefaults] integerForKey:@"port"];
+    NSString *hostAddress = [[NSUserDefaults standardUserDefaults] stringForKey:@"host-address"];
     
-    //#if TARGET_IPHONE_SIMULATOR
-        // on simulators we fall back to localhost, since the DEVELOPER_HOST (Host.current().name) turned out to be slightly unreliable
-    //#endif
-    [self startCaptureWithScaleUpFactor:scaleUpFactor cid:cid];
-  
+    if([hostAddress length] != 0) {
+        // if Repeato passes a host-address launch argument, it is a sign that it is an old Repeato version (<1.8.0)
+        DebugLog(self, @"Error: \"%s\" This iOS connector version is too new for your Repeato version. Please upgrade Repeato to 1.8.x or downgrade the iOS connector version to 1.2.x", hostAddress);
+    } else {
+        [self startCaptureWithScaleUpFactor:scaleUpFactor port:port];
+    }
 }
 @end


### PR DESCRIPTION
Because of restrictions in iOS 17 on physical devices in terms of connections being made to hosts in the local network, we decided to turn the connection mechanism around. Instead of running a server socket on the automation host side and a client on the app side, we now run the server socket inside the connector and connect to from the automation host side.
This comes with pros and cons, but overall it seems to be an improvement.
The port can be configured via the `-port` launch argument.